### PR TITLE
Add command line arguments to tweak default paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,17 @@ On the host the server runs which listens to the socket for browser calls and fo
 3) Make the server run as a service (insert SystemD here)
 4) Link the `/var/run/browser.sock` socket to the container
 
-Note: it doesn't work in every app yet due some diversity. It works in Slack!
+Note: it doesn't work in every app yet due some diversity. It works in Slack! Some apps, like Thunderbird, can also be modified to point to the correct application that opens the browser.
+
+### Optional command line arguments for the server part
+
+```
+Usage of x-www-browser-forwarder:
+  -browser-cmd string
+        Command to open URL (default "x-www-browser")
+  -socket-file string
+        Socket address (default "/var/run/browser.sock")
+```
+
+Note: The client defaults are not adjustable since you have full control with Docker on how to map the browser command and socket into the container.
+

--- a/server/main.go
+++ b/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net"
 	"os"
@@ -8,9 +9,15 @@ import (
 	"strings"
 )
 
-const socketAddr = "/var/run/browser.sock"
+const defaultSocketAddr = "/var/run/browser.sock"
+const defaultBrowserCmd = "x-www-browser"
 
-func serveSocket(c net.Conn) {
+type Config struct {
+	socketAddr string
+	browserCmd string
+}
+
+func serveSocket(c net.Conn, browserCmd string) {
 	for {
 		buf := make([]byte, 512)
 		nr, err := c.Read(buf)
@@ -19,16 +26,57 @@ func serveSocket(c net.Conn) {
 		}
 
 		data := string(buf[0:nr])
-		exec.Command("x-www-browser", strings.Split(data, " ")...).Output()
+		exec.Command(browserCmd, strings.Split(data, " ")...).Output()
 	}
 }
 
+// Check if a file exists directly or in PATH
+func checkIfFileExistsInPath(file string) bool {
+	// Check if the file exists as it
+	_, err := os.Stat(file)
+	if err == nil {
+		return true
+	}
+
+	// Check if the file exists in PATH
+	for _, path := range strings.Split(os.Getenv("PATH"), ":") {
+		file := []string{path, "/", file}
+		_, err = os.Stat(strings.Join(file, ""))
+		if err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Get command line arguments
+func getArgs() Config {
+	flags := flag.NewFlagSet("x-www-browser-forwarder", flag.ExitOnError)
+	browserCmd := flags.String("browser-cmd", defaultBrowserCmd, "Command to open URL")
+	socketFile := flags.String("socket-file", defaultSocketAddr, "Socket address")
+	flags.Parse(os.Args[1:])
+
+	if checkIfFileExistsInPath(*browserCmd) != true {
+		log.Fatal("Browser command not found: ", *browserCmd)
+	}
+
+	conf := Config{
+		socketAddr: *socketFile,
+		browserCmd: *browserCmd,
+	}
+
+	return conf
+}
+
 func main() {
-	l, err := net.Listen("unix", socketAddr)
+	config := getArgs()
+
+	l, err := net.Listen("unix", config.socketAddr)
 	if err != nil {
 		log.Fatal("listen error:", err)
 	}
-	defer os.Remove(socketAddr)
+	defer os.Remove(config.socketAddr)
 
 	for {
 		conn, err := l.Accept()
@@ -36,6 +84,6 @@ func main() {
 			log.Fatal("accept error:", err)
 		}
 
-		go serveSocket(conn)
+		go serveSocket(conn, config.browserCmd)
 	}
 }


### PR DESCRIPTION
This commit adds two command line arguments to overwrite the default socket and browser command.

This allows more flexibility since the default /var/run (/run) isn't writeable as regular user and can now be mapped to another folder that is writeable by a regular user.

An overwrite of the x-www-browser command allows the use alternative scripts that can spin up the URLs itself in a docker container without the need to overwrite the default x-www-browser settings.